### PR TITLE
Removed SOURCE param form documentation since it's not longer used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ A Docker container running statsd, using Stackdriver as backend.
 # Usage
 To run the container execute
 
-    docker run -e "STACKDRIVER_API_KEY=your_key" -e "SOURCE=stats_source" -p 8125:8125/udp fiunchinho/docker-statsd
+    docker run -e "STACKDRIVER_API_KEY=your_key" -p 8125:8125/udp fiunchinho/docker-statsd


### PR DESCRIPTION
With https://github.com/fiunchinho/docker-statsd/commit/3051c610ff886dd9e993f98dfe77dc30e0aa098a `SOURCE` var is not used anymore.
